### PR TITLE
Switch to labels

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -150,7 +150,6 @@ func main() {
 	registry.MustRegister(collector.NewKubernetesCollector(s, client, log))
 	registry.MustRegister(collector.NewLoadBalancerCollector(s, client, log))
 	registry.MustRegister(collector.NewReservedIPsCollector(s, client, log))
-	registry.MustRegister(collector.NewBillingCollector(s, client, log))
 
 	mux := http.NewServeMux()
 	mux.Handle("/", http.HandlerFunc(handleRoot))

--- a/collector/account.go
+++ b/collector/account.go
@@ -82,13 +82,9 @@ func (c *AccountCollector) Collect(ch chan<- prometheus.Metric) {
 
 		account, _, err := c.Client.Account.Get(ctx)
 		if err != nil {
-			log.Info("Unable to get account details")
+			log.Error(err, "Unable to get account details")
 			return
 		}
-
-		log.Info("Response",
-			"account", account,
-		)
 
 		ch <- prometheus.MustNewConstMetric(
 			c.Balance,

--- a/collector/bandwidth.go
+++ b/collector/bandwidth.go
@@ -34,7 +34,7 @@ func NewBandwidthCollector(s System, client *govultr.Client, log logr.Logger) Ba
 		Value: prometheus.NewDesc(
 			prometheus.BuildFQName(s.Namespace, "account_bandwidth", "value"),
 			"Bandwidth metric value",
-			[]string{"period", "metric", "unit"},
+			[]string{"period", "type", "unit"},
 			nil,
 		),
 	}
@@ -73,12 +73,12 @@ func (c BandwidthCollector) collectPeriod(ch chan<- prometheus.Metric, p govultr
 		"overage_cost":                {float64(p.OverageCost), "USD"},
 	}
 
-	for metricName, data := range metrics {
+	for typeName, data := range metrics {
 		ch <- prometheus.MustNewConstMetric(
 			c.Value,
 			prometheus.GaugeValue,
 			data.value,
-			[]string{period, metricName, data.unit}...,
+			[]string{period, typeName, data.unit}...,
 		)
 	}
 }

--- a/collector/bandwidth.go
+++ b/collector/bandwidth.go
@@ -2,7 +2,6 @@ package collector
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
@@ -14,45 +13,30 @@ var (
 )
 
 // BandwidthCollector represents Account Bandwidth
-// This comprises repeated (3) occurrences of BandwidthPeriod structs
 type BandwidthCollector struct {
 	System System
 	Client *govultr.Client
 	Log    logr.Logger
 
-	Previous  BandwidthPeriodCollector
-	Current   BandwidthPeriodCollector
-	Projected BandwidthPeriodCollector
+	// Single metric that captures all bandwidth-related values
+	// Using labels for period (current/previous/projected) and metric type (gb_in/gb_out/etc)
+	// This allows for easier querying and aggregation across periods and metric types
+	Value *prometheus.Desc
 }
 
 // NewBandwidthCollector creates a new BandwidthCollector
 func NewBandwidthCollector(s System, client *govultr.Client, log logr.Logger) BandwidthCollector {
-	// Ensure each bandwidth month's subsystem is unique
-	// The namespace and subsystem are used to create uniquely named metrics
-	previous := NewBandwidthPeriod(System{
-		Namespace: s.Namespace,
-		Subsystem: fmt.Sprintf("%s_previous", s.Subsystem),
-		Version:   s.Version,
-	}, client, log)
-	current := NewBandwidthPeriod(System{
-		Namespace: s.Namespace,
-		Subsystem: fmt.Sprintf("%s_current", s.Subsystem),
-		Version:   s.Version,
-	}, client, log)
-	projected := NewBandwidthPeriod(System{
-		Namespace: s.Namespace,
-		Subsystem: fmt.Sprintf("%s_projected", s.Subsystem),
-		Version:   s.Version,
-	}, client, log)
-
 	return BandwidthCollector{
 		System: s,
 		Client: client,
 		Log:    log,
 
-		Previous:  previous,
-		Current:   current,
-		Projected: projected,
+		Value: prometheus.NewDesc(
+			prometheus.BuildFQName(s.Namespace, "account_bandwidth", "value"),
+			"Bandwidth metric value",
+			[]string{"period", "metric", "unit"},
+			nil,
+		),
 	}
 }
 
@@ -64,18 +48,44 @@ func (c BandwidthCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	// Collect metrics for each BandwidthPeriod
-	c.Previous.Collect(ch, bandwidth.PreviousMonth)
-	c.Current.Collect(ch, bandwidth.CurrentMonthToDate)
-	c.Projected.Collect(ch, bandwidth.CurrentMonthProjected)
+	// Collect metrics for each period
+	c.collectPeriod(ch, bandwidth.PreviousMonth, "previous")
+	c.collectPeriod(ch, bandwidth.CurrentMonthToDate, "current")
+	c.collectPeriod(ch, bandwidth.CurrentMonthProjected, "projected")
 }
 
-// Desc	ribe implements Prometheus' Collector interface and is used to describe metrics
+// collectPeriod collects metrics for a specific bandwidth period
+func (c BandwidthCollector) collectPeriod(ch chan<- prometheus.Metric, p govultr.AccountBandwidthPeriod, period string) {
+	// Map of metric name to its value and unit
+	metrics := map[string]struct {
+		value float64
+		unit  string
+	}{
+		"gb_in":                       {float64(p.GBIn), "GB"},
+		"gb_out":                      {float64(p.GBOut), "GB"},
+		"total_instance_hours":        {float64(p.TotalInstanceHours), "hours"},
+		"total_instance_count":        {float64(p.TotalInstanceCount), "count"},
+		"instance_bandwidth_credits":  {float64(p.InstanceBandwidthCredits), "credits"},
+		"free_bandwidth_credits":      {float64(p.FreeBandwidthCredits), "credits"},
+		"purchased_bandwidth_credits": {float64(p.PurchasedBandwidthCredits), "credits"},
+		"overage":                     {float64(p.Overage), "GB"},
+		"overage_unit_cost":           {float64(p.OverageUnitCost), "USD"},
+		"overage_cost":                {float64(p.OverageCost), "USD"},
+	}
+
+	for metricName, data := range metrics {
+		ch <- prometheus.MustNewConstMetric(
+			c.Value,
+			prometheus.GaugeValue,
+			data.value,
+			[]string{period, metricName, data.unit}...,
+		)
+	}
+}
+
+// Describe implements Prometheus' Collector interface and is used to describe metrics
 func (c BandwidthCollector) Describe(ch chan<- *prometheus.Desc) {
-	// Describe metrics for each BandwidthPeriod
-	c.Previous.Describe(ch)
-	c.Current.Describe(ch)
-	c.Projected.Describe(ch)
+	ch <- c.Value
 }
 
 // BandwidthPeriodCollector represents BandwidthPeriod

--- a/collector/billing.go
+++ b/collector/billing.go
@@ -44,7 +44,7 @@ func getCollectorKey(product, description string) string {
 func (c *BillingCollector) getAllPendingCharges(ctx context.Context) ([]govultr.InvoiceItem, error) {
 	var allItems []govultr.InvoiceItem
 	options := &govultr.ListOptions{
-		PerPage: 100,
+		PerPage: 500,
 	}
 
 	for {

--- a/collector/billing_test.go
+++ b/collector/billing_test.go
@@ -69,15 +69,12 @@ var (
 	// Either the Collector is changed (e.g. labels added|removed)
 	// Or the responsePendingCharges changes
 	prometheusPendingCharges string = `
-	# HELP vultr_billing_total Total
-	# TYPE vultr_billing_total gauge
-	vultr_billing_total{product="Load Balancer",description="Load Balancer (my-loadbalancer)"} 10
-	# HELP vultr_billing_unit_price Unit Price
-	# TYPE vultr_billing_unit_price gauge
-	vultr_billing_unit_price{product="Load Balancer",description="Load Balancer (my-loadbalancer)",unit_type="hours"} 0.01489999983459711
-	# HELP vultr_billing_units Units
-	# TYPE vultr_billing_units gauge
-	vultr_billing_units{product="Load Balancer",description="Load Balancer (my-loadbalancer)",unit_type="hours"} 720
+	# HELP test_billing_total Total cost
+	# TYPE test_billing_total gauge
+	test_billing_total{description="Load Balancer (my-loadbalancer)",product="Load Balancer"} 10
+	# HELP test_billing_units Number of units consumed
+	# TYPE test_billing_units gauge
+	test_billing_units{description="Load Balancer (my-loadbalancer)",product="Load Balancer",unit_price="0.014900",unit_type="hours"} 720
 	`
 )
 

--- a/collector/billing_test.go
+++ b/collector/billing_test.go
@@ -69,15 +69,15 @@ var (
 	// Either the Collector is changed (e.g. labels added|removed)
 	// Or the responsePendingCharges changes
 	prometheusPendingCharges string = `
-	# HELP test_billing_load_balancer_total Total
-	# TYPE test_billing_load_balancer_total gauge
-	test_billing_load_balancer_total 10
-	# HELP test_billing_load_balancer_unit_price Unit Price
-	# TYPE test_billing_load_balancer_unit_price gauge
-	test_billing_load_balancer_unit_price{unit_type="hours"} 0.01489999983459711
-	# HELP test_billing_load_balancer_units Units
-	# TYPE test_billing_load_balancer_units gauge
-	test_billing_load_balancer_units{unit_type="hours"} 720
+	# HELP vultr_billing_total Total
+	# TYPE vultr_billing_total gauge
+	vultr_billing_total{product="Load Balancer",description="Load Balancer (my-loadbalancer)"} 10
+	# HELP vultr_billing_unit_price Unit Price
+	# TYPE vultr_billing_unit_price gauge
+	vultr_billing_unit_price{product="Load Balancer",description="Load Balancer (my-loadbalancer)",unit_type="hours"} 0.01489999983459711
+	# HELP vultr_billing_units Units
+	# TYPE vultr_billing_units gauge
+	vultr_billing_units{product="Load Balancer",description="Load Balancer (my-loadbalancer)",unit_type="hours"} 720
 	`
 )
 

--- a/collector/billing_test.go
+++ b/collector/billing_test.go
@@ -69,9 +69,9 @@ var (
 	// Either the Collector is changed (e.g. labels added|removed)
 	// Or the responsePendingCharges changes
 	prometheusPendingCharges string = `
-	# HELP test_billing_total Total cost
-	# TYPE test_billing_total gauge
-	test_billing_total{description="Load Balancer (my-loadbalancer)",product="Load Balancer"} 10
+	# HELP test_billing_cost_usd Total cost in USD
+	# TYPE test_billing_cost_usd gauge
+	test_billing_cost_usd{description="Load Balancer (my-loadbalancer)",product="Load Balancer"} 10
 	# HELP test_billing_units Number of units consumed
 	# TYPE test_billing_units gauge
 	test_billing_units{description="Load Balancer (my-loadbalancer)",product="Load Balancer",unit_price="0.014900",unit_type="hours"} 720

--- a/collector/exporter.go
+++ b/collector/exporter.go
@@ -46,10 +46,6 @@ func NewExporterCollector(s System, b Build, log logr.Logger) *ExporterCollector
 
 // Collect implements Prometheus' Collector interface and is used to collect metrics
 func (c *ExporterCollector) Collect(ch chan<- prometheus.Metric) {
-	log := c.Log.WithName("Collect")
-	log.Info("Metrics",
-		"start_time", c.Build.StartTime,
-	)
 	ch <- prometheus.MustNewConstMetric(
 		c.StartTime,
 		prometheus.GaugeValue,

--- a/collector/invoice_item.go
+++ b/collector/invoice_item.go
@@ -56,8 +56,8 @@ func NewInvoiceItemCollector(s System, client *govultr.Client, log logr.Logger) 
 			nil,
 		),
 		Total: prometheus.NewDesc(
-			prometheus.BuildFQName(s.Namespace, "billing", "total"),
-			"Total cost",
+			prometheus.BuildFQName(s.Namespace, "billing", "cost_usd"),
+			"Total cost in USD",
 			[]string{
 				"product",
 				"description",

--- a/collector/invoice_item.go
+++ b/collector/invoice_item.go
@@ -45,7 +45,7 @@ func NewInvoiceItemCollector(s System, client *govultr.Client, log logr.Logger) 
 		Log:    log,
 
 		Units: prometheus.NewDesc(
-			prometheus.BuildFQName(s.Namespace, "billing", "units"),
+			prometheus.BuildFQName(s.Namespace, s.Subsystem, "units"),
 			"Number of units consumed",
 			[]string{
 				"product",
@@ -56,7 +56,7 @@ func NewInvoiceItemCollector(s System, client *govultr.Client, log logr.Logger) 
 			nil,
 		),
 		Total: prometheus.NewDesc(
-			prometheus.BuildFQName(s.Namespace, "billing", "cost_usd"),
+			prometheus.BuildFQName(s.Namespace, s.Subsystem, "cost_usd"),
 			"Total cost in USD",
 			[]string{
 				"product",

--- a/collector/invoice_item.go
+++ b/collector/invoice_item.go
@@ -8,7 +8,10 @@ import (
 	"github.com/vultr/govultr/v3"
 )
 
-// InvoiceItemCollector represents a single invoice item
+// InvoiceItemCollector represents a single invoice item type and handles metric aggregation.
+// It collects and aggregates metrics for a specific product type, ensuring that multiple
+// invoice items of the same type are properly combined before being emitted as Prometheus metrics.
+// This prevents duplicate metrics and ensures accurate totals.
 type InvoiceItemCollector struct {
 	System System
 	Client *govultr.Client
@@ -18,10 +21,11 @@ type InvoiceItemCollector struct {
 	UnitPrice *prometheus.Desc
 	Totals    *prometheus.Desc
 
-	// Store aggregated values
-	currentUnits     map[string]float64
-	currentUnitPrice map[string]float64
-	currentTotal     float64
+	// Store aggregated values for the current collection cycle
+	// These maps are cleared after metrics are emitted
+	currentUnits     map[string]float64 // Maps unit_type to total units
+	currentUnitPrice map[string]float64 // Maps unit_type to latest unit price
+	currentTotal     float64            // Running total for all items
 }
 
 // NewInvoiceItemCollector creates a new InvoiceItemCollector


### PR DESCRIPTION
# Redesign metrics to use labels instead of metric name embedding

This PR completely redesigns the metric structure to follow Prometheus best practices by using labels instead of embedding information in metric names.

## Key Changes

### Metric Structure
- Consolidated metrics into a single `vultr_account_bandwidth_value` metric with labels
- Replaced product-specific billing metrics with generic `billing_cost_usd` and `billing_units` metrics
- Renamed `kubernetes_node` to `kubernetes_node_pool_nodes` for clarity
- Added `block_type` label to Block Storage metrics

### API Improvements
- Added pagination support to all API calls (Block Storage, Kubernetes, Load Balancer, Reserved IPs)
- Increased billing API page size to 500 items to get reporting on large lists
- Improved error logging with detailed error messages
- Removed excessive debug logging statements

### Documentation
- Added more metrics documentation in README
- Added useful PromQL query examples for common use cases
- Added examples for cost analysis, resource usage, and filtering

## Testing
- Updated test expectations to match new metric format
- All tests passing
- Manually verified complete resource collection with pagination